### PR TITLE
Replace eth0 with interface from default route

### DIFF
--- a/SCRIPT/MOTD.sh
+++ b/SCRIPT/MOTD.sh
@@ -22,6 +22,7 @@ USER=`whoami`
 ADMINS=`cat /etc/group | grep --regex "^sudo" | awk -F: '{print $4}' | tr ',' '|'`
 ADMINSLIST=`grep -E $ADMINS /etc/passwd | tr ':' ' ' | tr ',' ' ' | awk {'print $5,$6,"("$1")"'} | tr '\n' ',' | sed '$s/.$//'`
 UPDATESAVAIL=`cat /var/zzscriptzz/MOTD/updates-available.dat`
+INTERFACE=`route | grep '^default' | grep -o '[^ ]*$'`
 
 if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
         cur_temperature=$(cat /sys/class/thermal/thermal_zone0/temp)
@@ -70,7 +71,7 @@ echo -e " ${C0}+                    +                     +         +
 
 echo -e "${C1} ++++++++++++++++++++++++: ${C3}System Data${C1} :+++++++++++++++++++++++++++
 ${C1} + ${C3}Hostname       ${C1}=  ${C4}`hostname` ${C0}(`hostname --fqdn`)
-${C1} + ${C3}IPv4 Address   ${C1}=  ${C4}`wget http://ipinfo.io/ip -qO -` ${C0}(`ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1`)
+${C1} + ${C3}IPv4 Address   ${C1}=  ${C4}`wget http://ipinfo.io/ip -qO -` ${C0}(`ip addr list $INTERFACE |grep "inet " |cut -d' ' -f6|cut -d/ -f1`)
 ${C1} + ${C3}Uptime         ${C1}=  ${C4}`uptime | sed -E 's/^[^,]*up *//; s/, *[[:digit:]]* users.*//; s/min/minutes/; s/([[:digit:]]+):0?([[:digit:]]+)/\1 hours, \2 minutes/'`
 ${C1} + ${C3}Time           ${C1}=  ${C0}`date`
 ${C1} + ${C3}CPU T°         ${C1}=  ${C0}$cur_temperature


### PR DESCRIPTION
Hello, I found that the interface is hard-coded to **eth0** for the **IPv4 Address** field. 
Would it be better if it uses the interface name from the default route using `route` command?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/habilya/ssh-welcome-screen/14)
<!-- Reviewable:end -->
